### PR TITLE
Fix submodule root not found

### DIFF
--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -178,7 +178,10 @@ endfunction
 
 function! s:project_root_dir() abort
   let current_file_dir = expand('%:p:h')
-  let git_dir = finddir('.git', expand('%:p:h') . ';')
+  let git_dir = findfile('.git', expand('%:p:h') . ';')
+  if git_dir ==# ''
+    let git_dir = finddir('.git', expand('%:p:h') . ';')
+  endif
 
   if git_dir ==# ''
     throw 'Not a git repository'


### PR DESCRIPTION
.git files in a submodule can be a file instead of of a directory.
The use of finddir means that within a submodule the .git of the
submodule will ignore resulting in tig being launch for the parent.
By trying to find a file fist we sort this problem.

It might be a problem in a case of nested submodules using files
and dirs.