### PR TITLE
Update to change dir to root dir temporarily when opening file

### DIFF
--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -191,12 +191,20 @@ function! s:exec_tig_command(tig_args) abort
 endfunction
 
 function! s:open_file() abort
-  if filereadable(s:path_file)
+  if !filereadable(s:path_file)
+    return
+  endif
+
+  let current_dir = getcwd()
+  try
+    execute 'lcd ' . fnamemodify(s:project_root_dir(), ':p')
     for f in readfile(s:path_file)
       exec f
     endfor
+  finally
     call delete(s:path_file)
-  endif
+    execute 'lcd ' . fnamemodify(current_dir, ':p')
+  endtry
 endfunction
 
 function! s:project_root_dir() abort


### PR DESCRIPTION
tig-explorer cannot open file correctly when current directory is not the project root directory, because `tig` command is executed from project root.

This PR will update opening file process to change directory to the project root directory temporarily.

Steps to reproduce:
```sh
$ mkdir -p /tmp/foo/bar
$ cd /tmp/foo
$ git init
Initialized empty Git repository in /private/tmp/foo/.git/
$ echo baz > bar/baz && git add bar/baz
$ cd bar
$ vim
```

```vim
" Working directory shoud be /tmp/foo/bar
:pwd
" It should fail to open 'baz' file because tig-explorer try to open 'bar/baz' from '/tmp/foo/bar' directory
:TigStatus
```