### PR TITLE
Removes unnecessary bang on Bclose command

### DIFF
--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -137,7 +137,7 @@ endfunction
 function! s:tig_callback(exit_code) abort
   if a:exit_code == 0
     if has('nvim')
-      silent! Bclose!
+      silent! Bclose
     else
       let current_buf = bufnr('%')
       silent! buffer #


### PR DESCRIPTION
I'm using [SpaceVim](https://spacevim.org/) and ran into an error where it's custom [`close_term_buffer`](https://github.com/SpaceVim/SpaceVim/blob/64dc68d796aa5e753a0ce5b05db188bb92fdb5ec/autoload/SpaceVim/mapping.vim#L208) function would throw an error each time I attempted to edit a file from within `tig-explorer.vim`:
```
Error detected while processing function SpaceVim#mapping#close_term_buffer:
line   18:
E516: No buffers were deleted: bd! 8
```

This was being thrown because [`s:tig_callback` adds a bang to the Bclose command on Line 140](https://github.com/iberianpig/tig-explorer.vim/blob/master/autoload/tig_explorer.vim#L140). AFAIK, adding a bang here seems unnecessary and can cause conflicts with other window/buffer managers like the example above. By removing the bang from that one line, I am able to edit files from `tig-explorer.vim` without any errors.

BTW, thanks very much for providing the `tig-explorer.vim` plugin! It's really great to have the option of using Tig inside Vim! 🙏