### PR TITLE
Add :TigOpenWithCommit and corresponding key binding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ e, <Ctrl-o>: edit on existing tab
 <Ctrl-s>   : edit with split window
 ```
 
+When a commit is available (in main, blame, tree, refs view) view, the version of the file corresponding to this commit
+will be open instead of the version in the working directory. Split versions will open the two buffer in diff mode.
+
 ##### Customize Keymap on Tig
 Following keymap is defined as defaut
 ```vim

--- a/doc/tig-explorer.txt
+++ b/doc/tig-explorer.txt
@@ -69,6 +69,24 @@ TigGrepResume                                                 *:TigGrepResume*
 TigBlame                                                           *:TigBlame*
     Open tig blame with current file
 
+TigOpenFileWithCommit
+    Open a file at the given commit.  `:TigOpenWithCommit COMMIT FILE LINEO`
+    All arguments are optional.
+    If FILE contains `%` and `FILE` is contains so commit information.
+    The `%` in the commit will be replaced with the original commit.
+
+    For example `:TigOpenWithCommit %~` open the previous version of the
+    current file. This file will be called `HEAD~:file`.
+    Calling `:TigOpenFileWithCommit %~` again will open the previous version
+    of the previous version (`HEAD~~`).
+
+TigOpenFileWithCommit!
+    Like TigOpenFileWithCommit but show the diff between the current buffer
+    and the resulting buffer.
+
+    For example, `:vertical TigOpenFileWithCommit! HEAD` set a side by side
+    diff between the current buffer and its HEAD version.
+
 ==============================================================================
 KEYMAPS                                                 *tig-explorer-keymaps*
 
@@ -79,6 +97,9 @@ e, <Ctrl-o>: edit on existing tab
 <Ctrl-s>   : edit with split window
 <Ctrl-v>   : edit with vsplit window
 
+ When a commit is available (in main, blame, tree, refs view) view, the version of the file corresponding to this commit
+will be open instead of the version in the working directory. Split versions will open the two buffer in diff mode.
+ 
 ==============================================================================
 CUSTOMIZE                                             *tig-explorer-customize*
 

--- a/plugin/tig_explorer.vim
+++ b/plugin/tig_explorer.vim
@@ -35,5 +35,9 @@ command! TigGrepResume
 command! TigStatus
       \  call tig_explorer#status()
 
+command! -bang -nargs=* TigOpenFileWithCommit
+      \ call tig_explorer#open_file_with_commit("<bang>",<q-mods>,<f-args>)
+
 let &cpoptions = s:save_cpo
 unlet s:save_cpo
+

--- a/script/setup_tmp_tigrc.sh
+++ b/script/setup_tmp_tigrc.sh
@@ -21,6 +21,18 @@ cp "$orig_tigrc" "$tmp_tigrc"
 # $2: 'edit_cmd'
 add_custom_command() {
   echo "bind generic $1 <sh -c \"echo $2 +%(lineno) %(file) > $path_file\"" >> "$tmp_tigrc"
+  case $2 in
+    tabedit) command="tab TigOpenFileWithCommit";;  
+    split) command="TigOpenFileWithCommit!";; 
+    vsplit) command="vertical TigOpenFileWithCommit!";; 
+    *) command="TigOpenFileWithCommit";; 
+  esac
+
+  echo "bind tree $1 <sh -c \"echo $command %(commit) %(file) %(lineno) > $path_file\"" >> "$tmp_tigrc"
+  for keymap in blame refs main diff
+  do
+    echo "bind $keymap $1 <sh -c \"echo $command %(commit) % %(lineno) > $path_file\"" >> "$tmp_tigrc"
+  done
 }
 
 add_custom_command "e"               "edit"


### PR DESCRIPTION
Allows to open a file from the specify commit.
Works with normal edit bindings in main, tree, refs, blame view.

I understand this plugin might try to be lightweight and this commit might seem heavy.
However the new command is necessary to make the blame view (or history view) editing work,
meaning when you press `e` whilst browsing the history of a file , it open (not the file, which is usually open) but a new buffer with the selected version of this file (which is the behavior of tig outside vim).. Split mode open a diff (because if I open side by side a file and old version, I probably want to diff them).

I understand the doc might not be great, feel free to ask me for clarification if needed.

