### PR TITLE
fix(open_file_with_commit): invalid arguments' syntax in function

### DIFF
--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -89,22 +89,27 @@ endfunction
 
 " Open a file for the given commit
 " Usefull when editing file from tree or blame view
-function tig_explorer#open_file_with_commit(diff, mods, commit='HEAD', file='', lineno=0)
+function! tig_explorer#open_file_with_commit(diff, mods, commit, file, lineno)
+  let commit = get(a:, 'commit', 'HEAD')
+  let file = get(a:, 'file', '')
+  let lineno = get(a:, 'lineno', 0)
+
   " if no file is provided use the current one
-  if a:file == ''
+  if file == ''
     let file0 = expand('%')
     let diff = 1
   else
-    let file0 = expand(a:file)
+    let file0 = expand(file)
   endif
   " split commit file if needed
+  echomsg file0
   let parts = split(file0, ':')
   if len(parts) == 2
-    let commit = substitute(a:commit, '%',  parts[0],'' )
+    let commit = substitute(commit, '%',  parts[0],'' )
     let file = parts[1]
   else
     let file = parts[0]
-    let commit = substitute(a:commit, '%', 'HEAD','')
+    let commit = substitute(commit, '%', 'HEAD','')
   endif
   if a:diff == '!'
     diffthis
@@ -133,7 +138,10 @@ function tig_explorer#open_file_with_commit(diff, mods, commit='HEAD', file='', 
     setlocal nomodified
     setlocal nomodifiable
     setlocal readonly
-    execute "+" a:lineno
+    execute "+" lineno
+    if a:diff=='!'
+      diffthis
+    endif
   endif
 endfunction
 
@@ -314,7 +322,7 @@ function! s:input(...) abort
   endtry
 endfunction
 
-function s:strip_commit(path)
+function! s:strip_commit(path)
   return substitute(a:path, '^[^:]*:','','')
 endfunction
 " Initialize

--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -94,6 +94,7 @@ function! tig_explorer#open_file_with_commit(diff, mods, commit, file, lineno)
   let file = get(a:, 'file', '')
   let lineno = get(a:, 'lineno', 0)
 
+  let file0 = ''
   " if no file is provided use the current one
   if file == ''
     let file0 = expand('%')
@@ -119,16 +120,13 @@ function! tig_explorer#open_file_with_commit(diff, mods, commit, file, lineno)
   if bufexists(ref)
     if a:diff == '!'
       execute a:mods "edit" ref
-      diffthis
     else
       execute a:mods "split" ref
     endif
-
   else
     let ftype=&filetype
     if a:diff == '!'
       execute a:mods "new"
-      diffthis
     else
       execute a:mods "enew"
     endif
@@ -139,9 +137,9 @@ function! tig_explorer#open_file_with_commit(diff, mods, commit, file, lineno)
     setlocal nomodifiable
     setlocal readonly
     execute "+" lineno
-    if a:diff=='!'
-      diffthis
-    endif
+  endif
+  if a:diff=='!'
+    diffthis
   endif
 endfunction
 


### PR DESCRIPTION
Avoid Syntax error when loading autoload/tig_explorer.vim

Closes #24