### PR TITLE
Split keybind to keymap_edit and keymap_commit_edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,24 @@ e, <Ctrl-o>: edit on existing tab
 <ESC> s: open with commit with split window
 ```
 
-When a commit is available (in main, blame, tree, refs view) view, the version of the file corresponding to this commit
-will be open instead of the version in the working directory. Split versions will open the two buffer in diff mode.
+When a commit is available (in main, blame, tree, refs view) view, the version
+of the file corresponding to this commit will be open instead of the version
+in the working directory. Split versions will open the two buffer in diff mode.
 
 #### Customize Keymap on Tig
+
 Following keymap is defined as defaut
+
 ```vim
 let g:tig_explorer_keymap_edit    = '<C-o>'
 let g:tig_explorer_keymap_tabedit = '<C-t>'
 let g:tig_explorer_keymap_split   = '<C-s>'
 let g:tig_explorer_keymap_vsplit  = '<C-v>'
+
+let g:tig_explorer_keymap_commit_edit    = '<ESC>o'
+let g:tig_explorer_keymap_commit_tabedit = '<ESC>t'
+let g:tig_explorer_keymap_commit_split   = '<ESC>s'
+let g:tig_explorer_keymap_commit_vsplit  = '<ESC>v'
 ```
 
 ### Keymap on Vim

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ e, <Ctrl-o>: edit on existing tab
 <Ctrl-t>   : edit on new tab
 <Ctrl-v>   : edit with vsplit window
 <Ctrl-s>   : edit with split window
+
+<ESC> o: open with commit on existing tab
+<ESC> t: open with commit on new tab
+<ESC> v: open with commit with vsplit window
+<ESC> s: open with commit with split window
 ```
 
 When a commit is available (in main, blame, tree, refs view) view, the version of the file corresponding to this commit

--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -187,6 +187,11 @@ function! s:initialize() abort
   let s:keymap_split   = get(g:, 'tig_explorer_keymap_split',   '<C-s>')
   let s:keymap_vsplit  = get(g:, 'tig_explorer_keymap_vsplit',  '<C-v>')
 
+  let s:keymap_commit_edit    = get(g:, 'tig_explorer_keymap_commit_edit',    '<ESC>o')
+  let s:keymap_commit_tabedit = get(g:, 'tig_explorer_keymap_commit_tabedit', '<ESC>t')
+  let s:keymap_commit_split   = get(g:, 'tig_explorer_keymap_commit_split',   '<ESC>s')
+  let s:keymap_commit_vsplit  = get(g:, 'tig_explorer_keymap_commit_vsplit',  '<ESC>v')
+
 
   let s:before_exec_tig  = s:plugin_root . '/script/setup_tmp_tigrc.sh'
         \ . ' ' . s:orig_tigrc
@@ -196,6 +201,10 @@ function! s:initialize() abort
         \ . ' "' . s:keymap_tabedit . '"'
         \ . ' "' . s:keymap_split   . '"'
         \ . ' "' . s:keymap_vsplit  . '"'
+        \ . ' "' . s:keymap_commit_edit    . '"'
+        \ . ' "' . s:keymap_commit_tabedit . '"'
+        \ . ' "' . s:keymap_commit_split   . '"'
+        \ . ' "' . s:keymap_commit_vsplit  . '"'
 
   let s:tig_prefix = 'TIGRC_USER=' . s:tmp_tigrc . ' '
 endfunction

--- a/doc/tig-explorer.txt
+++ b/doc/tig-explorer.txt
@@ -97,8 +97,15 @@ e, <Ctrl-o>: edit on existing tab
 <Ctrl-s>   : edit with split window
 <Ctrl-v>   : edit with vsplit window
 
- When a commit is available (in main, blame, tree, refs view) view, the version of the file corresponding to this commit
-will be open instead of the version in the working directory. Split versions will open the two buffer in diff mode.
+<ESC> o: open with commit on existing tab
+<ESC> t: open with commit on new tab
+<ESC> v: open with commit with vsplit window
+<ESC> s: open with commit with split window
+
+ When a commit is available (in main, blame, tree, refs view) view, the
+ version of the file corresponding to this commit will be open instead of the
+ version in the working directory. Split versions will open the two buffer in
+ diff mode.
  
 ==============================================================================
 CUSTOMIZE                                             *tig-explorer-customize*

--- a/script/setup_tmp_tigrc.sh
+++ b/script/setup_tmp_tigrc.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ $# -ne 7 ]; then
+if [ $# -ne 11 ]; then
   echo "require 7 argument"
   exit 1
 fi
@@ -11,32 +11,65 @@ keymap_edit=$4
 keymap_tabedit=$5
 keymap_split=$6
 keymap_vsplit=$7
+keymap_commit_edit=$8
+keymap_commit_tabedit=$9
+keymap_commit_split=$10
+keymap_commit_vsplit=$11
 
 # make temporary tigrc
 cp "$orig_tigrc" "$tmp_tigrc"
 
 # Overwriting temporary tigrc
 
-# $1: 'keymap'
-# $2: 'edit_cmd'
-add_custom_command() {
-  echo "bind generic $1 <sh -c \"echo $2 +%(lineno) %(file) > $path_file\"" >> "$tmp_tigrc"
-  case $2 in
-    tabedit) command="tab TigOpenFileWithCommit";;  
-    split) command="TigOpenFileWithCommit!";; 
-    vsplit) command="vertical TigOpenFileWithCommit!";; 
-    *) command="TigOpenFileWithCommit";; 
-  esac
 
-  echo "bind tree $1 <sh -c \"echo $command %(commit) %(file) %(lineno) > $path_file\"" >> "$tmp_tigrc"
-  for keymap in blame refs main diff
-  do
-    echo "bind $keymap $1 <sh -c \"echo $command %(commit) % %(lineno) > $path_file\"" >> "$tmp_tigrc"
-  done
+add_custom_cmd() {
+  view=$1
+  keymap=$2
+  cmd=$3
+  echo "bind $view $keymap <sh -c \"echo $cmd +%(lineno) %(file) > $path_file\"" >> "$tmp_tigrc"
 }
 
-add_custom_command "e"               "edit"
-add_custom_command "$keymap_edit"    "edit"
-add_custom_command "$keymap_tabedit" "tabedit"
-add_custom_command "$keymap_split"   "split"
-add_custom_command "$keymap_vsplit"  "vsplit"
+add_current_with_commit_cmd() {
+  view=$1
+  keymap=$2
+  cmd=$3
+  echo "bind $view $keymap <sh -c \"echo $cmd %(commit) % %(lineno) > $path_file\"" >> "$tmp_tigrc"
+}
+
+add_selected_with_commit_cmd() {
+  view=$1
+  keymap=$2
+  cmd=$3
+  echo "bind $view $keymap <sh -c \"echo $cmd %(commit) %(file) %(lineno) > $path_file\"" >> "$tmp_tigrc"
+}
+
+add_custom_cmd "generic" "e"               "edit"
+add_custom_cmd "generic" "$keymap_edit"    "edit"
+add_custom_cmd "generic" "$keymap_tabedit" "tabedit"
+add_custom_cmd "generic" "$keymap_split"   "split"
+add_custom_cmd "generic" "$keymap_vsplit"  "vsplit"
+
+add_current_with_commit_cmd "refs" "$keymap_commit_edit"    "TigOpenFileWithCommit"
+add_current_with_commit_cmd "refs" "$keymap_commit_tabedit" "tab TigOpenFileWithCommit"
+add_current_with_commit_cmd "refs" "$keymap_commit_split"   "TigOpenFileWithCommit!"
+add_current_with_commit_cmd "refs" "$keymap_commit_vsplit"  "vertical TigOpenFileWithCommit!"
+
+add_current_with_commit_cmd "main" "$keymap_commit_edit"    "TigOpenFileWithCommit"
+add_current_with_commit_cmd "main" "$keymap_commit_tabedit" "tab TigOpenFileWithCommit"
+add_current_with_commit_cmd "main" "$keymap_commit_split"   "TigOpenFileWithCommit!"
+add_current_with_commit_cmd "main" "$keymap_commit_vsplit"  "vertical TigOpenFileWithCommit!"
+
+add_selected_with_commit_cmd "blame" "$keymap_commit_edit"    "TigOpenFileWithCommit"
+add_selected_with_commit_cmd "blame" "$keymap_commit_tabedit" "tab TigOpenFileWithCommit"
+add_selected_with_commit_cmd "blame" "$keymap_commit_split"   "TigOpenFileWithCommit!"
+add_selected_with_commit_cmd "blame" "$keymap_commit_vsplit"  "vertical TigOpenFileWithCommit!"
+
+add_selected_with_commit_cmd "diff" "$keymap_commit_edit"    "TigOpenFileWithCommit"
+add_selected_with_commit_cmd "diff" "$keymap_commit_tabedit" "tab TigOpenFileWithCommit"
+add_selected_with_commit_cmd "diff" "$keymap_commit_split"   "TigOpenFileWithCommit!"
+add_selected_with_commit_cmd "diff" "$keymap_commit_vsplit"  "vertical TigOpenFileWithCommit!"
+
+add_selected_with_commit_cmd "tree" "$keymap_commit_edit"    "TigOpenFileWithCommit"
+add_selected_with_commit_cmd "tree" "$keymap_commit_tabedit" "tab TigOpenFileWithCommit"
+add_selected_with_commit_cmd "tree" "$keymap_commit_split"   "TigOpenFileWithCommit!"
+add_selected_with_commit_cmd "tree" "$keymap_commit_vsplit"  "vertical TigOpenFileWithCommit!"


### PR DESCRIPTION
* Use Ctrl-key bindings to their old behavior(open file) on Tig
* Add Alt-(Esc) keybindings to support commit_with_edit features on Tig

```vim
# open the file selected
let g:tig_explorer_keymap_edit    = '<C-o>'
let g:tig_explorer_keymap_tabedit = '<C-t>'
let g:tig_explorer_keymap_split   = '<C-s>'
let g:tig_explorer_keymap_vsplit  = '<C-v>'

# open with the commit selected on Tig
let g:tig_explorer_keymap_commit_edit    = '<ESC>o'
let g:tig_explorer_keymap_commit_tabedit = '<ESC>t'
let g:tig_explorer_keymap_commit_split   = '<ESC>s'
let g:tig_explorer_keymap_commit_vsplit  = '<ESC>v'
```

It's useful to open in a specific commit and show a diff.
But we won't always want to open with a commit, so it should be another option.
Also, tig-explorer.vim behavior shoud be same with Tig. So this option is rule of least surpris, no confusion for the user in the context of whether you opened from tig-explorer.vim or Tig.