### PR TITLE
Fix no-found problem in open_project_root_dir

### DIFF
--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -27,12 +27,13 @@ endfunction
 
 function! tig_explorer#open_project_root_dir() abort
   try
-    let root_dir = s:project_root_dir()
+    let root_dir = fnamemodify(s:project_root_dir(), ':p')
+    let short_path = substitute(expand('%:p'), root_dir, "./", "")
   catch
     echoerr 'tig-explorer.vim: ' . v:exception
     return
   endtry
-  :call tig_explorer#open(root_dir)
+  :call tig_explorer#open(short_path)
 endfunction
 
 function! tig_explorer#grep(str) abort


### PR DESCRIPTION
Assume there is a .git under /home/aaa

Reproduce 1:
1. current folder is /
2. vim /home/aaa/xxx.c
3. Toggle open_project_root_dir would cause error