### PR TITLE
Get submodule's root dir as root dir if in submodule's git config dir

### DIFF
--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -296,16 +296,43 @@ endfunction
 
 function! s:project_root_dir() abort
   let current_file_dir = expand('%:p:h')
-  let git_dir = findfile('.git', expand('%:p:h') . ';')
+  let git_dir = findfile('.git', current_file_dir . ';')
   if git_dir ==# ''
-    let git_dir = finddir('.git', expand('%:p:h') . ';')
+    let git_dir = finddir('.git', current_file_dir . ';')
+
+    if git_dir ==# ''
+      throw 'Not a git repository: ' . current_file_dir
+    endif
+
+    let git_module_dir = finddir('modules', current_file_dir . ';')
+    if git_module_dir !=# ''
+      let git_module_dir_git = finddir('.git', fnamemodify(git_module_dir, ':p') . ';')
+      if fnamemodify(git_module_dir_git, ':p') ==# fnamemodify(git_dir, ':p')
+        " Now in submodule's config dir
+
+        let git_submodule_index = findfile('index', current_file_dir . ';')
+        if git_submodule_index !=# ''
+          let git_submodule_dir = fnamemodify(git_submodule_index, ':p:h')
+          let git_submodule_workdir = trim(system('cd ' . git_submodule_dir . '&& git config --get core.worktree'))
+          if git_submodule_workdir !=# ''
+            let git_submodule_workdir = glob(git_submodule_dir . '/' . git_submodule_workdir)
+          endif
+        endif
+      endif
+    endif
   endif
 
-  if git_dir ==# ''
-    throw 'Not a git repository: ' . expand('%:p:h')
+  if exists("git_submodule_workdir") && git_submodule_workdir !=# ''
+    let root_dir = git_submodule_workdir
+  else
+    if isdirectory(git_dir)
+      " XXX:  `:p` fullpath-conversion attaches `/` in the tail of dir path, e.g. `dir/.git/` .
+      "       Due to this, give one more `:h` modifier to remove the last part or `.git` .
+      let root_dir = fnamemodify(git_dir, ':p:h:h')
+    else
+      let root_dir = fnamemodify(git_dir, ':p:h')
+    endif
   endif
-
-  let root_dir = fnamemodify(git_dir, ':h')
 
   if !isdirectory(root_dir)
     return current_file_dir


### PR DESCRIPTION
If on submodule's config dir, open `tig` for the submodule.

Especially for compatibility with https://github.com/tpope/vim-fugitive plugin,
that opens git `index` file as the `Git` status command result.

----

| Work Dir             | Git Config Dir Ref File  | Actual Git Config Dir                     | Git `index` File                               |
|:---------------------|:-------------------------|:------------------------------------------|:-----------------------------------------------|
| `repoA/`             | (none)                   | `repoA/.git/`                             | `repoA/.git/index`                             |
| `repoA/repoB/`       | `repoA/repoB/.git`       | `repoA/.git/modules/repoB/`               | `repoA/.git/modules/repoB/index`               |
| `repoA/repoB/repoC/` | `repoA/repoB/repoC/.git` | `repoA/.git/modules/repoB/modules/repoC/` | `repoA/.git/modules/repoB/modules/repoC/index` |
| `repoA/dir/repoD/`   | `repoA/dir/repoD/.git`   | `repoA/.git/modules/dir/repoD/`           | `repoA/.git/modules/dir/repoD/index`           |

[Fugitive](https://github.com/tpope/vim-fugitive) plugin opens the git `index` file on `Git` command.

For example, `Git` window for submodule `repoA/repoB/` will be on `repoA/.git/modules/repoB/index`.

In the current `Tig` plugin implementation,
it searchs up to `repoA/.git/` and returns its parent dir `repoA/` to open `tig` for `repoA`.

Instead, to open `tig` for the submodule `repoB`, I tried to modify `s:project_root_dir()` method.

For example, on `repoB`'s `Git` window (i.e. `repoA/.git/modules/repoB/index`),

1. Try to find `.git` file (=> Find nothing)
2. Find `.git/` dir (i.e. `repoA/.git/`)
3. **Try to find submodule's config dir** in the current ancestral path
    1. Check whether the current path is in surely submodule's config dir
        1. Find `modules/` dir from the current path (i.e. `repoA/.git/modules/`)
        2. Find `.git/` dir from the `modules/` dir (i.e. `repoA/.git/`)
        3. If the `.git/` file is the same, now surely in the submodule config dir
    2. Find submodule's config dir's root
        1. Find `index` file from the current path (i.e. `repoA/.git/modules/repoB/index`)
        2. Its parent dir is submodule's config dir (i.e. `repoA/.git/modules/repoB/`)
    3. Move to the dir and get submodule work dir
        1. Move to the submodule's config dir (i.e. `repoA/.git/modules/repoB/`)
        2. Get git `core.worktree` option (i.e. `../../../repoB`, a relative path from the config dir)
        3. Resolve the workdir path
4. If submodule's workdir is found above, return it as the root dir

Considering sub-sub-module or descendant submodules such as `repoA/reopB/repoC`,
using `core.worktree` option would be better.