### PR TITLE
Use current window size to open `tig`

### DIFF
--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -265,6 +265,8 @@ function! s:exec_tig_command(tig_args) abort
     call term_start('env ' . command, {
          \ 'term_name': 'tig',
          \ 'curwin': v:true,
+         \ 'term_rows' : winheight('%'),
+         \ 'term_cols' : winwidth('%'),
          \ 'term_finish': 'close',
          \ 'exit_cb': {status, code -> s:tig_callback(code)},
          \ })


### PR DESCRIPTION
Make sure to open `tig` window as the current window size.

Default `term_start()` call uses `termwinsize` setting for opening terminal.

However, if `termwinsize` is set as `<ROWS>*<COLS>` (i.e. minimum size is ROW x COLS),
opening terminal buffer size shrinks to it.

For example, if the current window height x width =  40 x 160 and `termwinsize` = `0*128`,
it opens a `tig` terminal with its buffer size 40 x 128:
The terminal window size itself does not change (i.e. 40 x 160),
but `tig` output is cut out up to 40 x 128.

So, explicitly specify the current window size for `term_start()` of `tig` execution.
