### PR TITLE
Fix TigOpenFileWithCommit not using default args

### DIFF
--- a/autoload/tig_explorer.vim
+++ b/autoload/tig_explorer.vim
@@ -92,9 +92,9 @@ endfunction
 " Open a file for the given commit
 " Usefull when editing file from tree or blame view
 function! tig_explorer#open_file_with_commit(diff, mods, commit, file, lineno)
-  let commit = get(a:, 'commit', 'HEAD')
-  let file = get(a:, 'file', '')
-  let lineno = get(a:, 'lineno', 0)
+  let commit = a:commit ?? 'HEAD'
+  let file = a:file
+  let lineno = a:lineno ?? 0
 
   let file0 = ''
   " if no file is provided use the current one

--- a/plugin/tig_explorer.vim
+++ b/plugin/tig_explorer.vim
@@ -36,7 +36,8 @@ command! TigStatus
       \  call tig_explorer#status()
 
 command! -bang -nargs=* TigOpenFileWithCommit
-      \ call tig_explorer#open_file_with_commit("<bang>",<q-mods>,<f-args>)
+      \ call call('tig_explorer#open_file_with_commit',
+      \            slice(["<bang>",<q-mods>,<f-args>]+['','',''],0,5))
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Fixes TigOpenFileWithCommit broken if not all arguments are given.